### PR TITLE
fix(charts): can't find openkruise on charts repo

### DIFF
--- a/deploy/plugins/openkruise/templates/openkruise.yaml
+++ b/deploy/plugins/openkruise/templates/openkruise.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   kind: helm
   url: https://openkruise.github.io/charts/
+  chart: kruise
   version: "{{ .Chart.AppVersion }}"
   values:
     manager:


### PR DESCRIPTION
fix(charts): can't find openkruise on charts repo