### PR TITLE
bugfix; error handle default image registry;

### DIFF
--- a/pkg/service/handlers/registry/registry-hook.go
+++ b/pkg/service/handlers/registry/registry-hook.go
@@ -154,22 +154,9 @@ func updateEnviromentAnnotation(env *v1beta1.Environment, serviceAccountName, ta
 	if env.Annotations == nil {
 		env.Annotations = make(map[string]string)
 	}
-
-	if len(env.Annotations) == 0 && isAdd {
-		env.Annotations = map[string]string{
-			imagePullSecretKeyPrefix + serviceAccountName: targetSecretName,
-		}
-		return
-	}
-
-	for k := range env.Annotations {
-		if !strings.HasPrefix(k, imagePullSecretKeyPrefix) {
-			continue
-		}
-		if strings.TrimPrefix(k, imagePullSecretKeyPrefix) != serviceAccountName {
-			continue
-		}
-		secrets := strings.Split(env.Annotations[k], ",")
+	key := imagePullSecretKeyPrefix + serviceAccountName
+	if _, exist := env.Annotations[key]; exist {
+		secrets := strings.Split(env.Annotations[key], ",")
 		if isAdd {
 			if !slice.ContainStr(secrets, targetSecretName) {
 				secrets = append(secrets, targetSecretName)
@@ -177,11 +164,14 @@ func updateEnviromentAnnotation(env *v1beta1.Environment, serviceAccountName, ta
 		} else {
 			secrets = slice.RemoveStrInReplace(secrets, targetSecretName)
 		}
-
 		if len(secrets) == 0 {
-			env.Annotations = nil
+			delete(env.Annotations, key)
 		} else {
-			env.Annotations[k] = strings.Join(secrets, ",")
+			env.Annotations[key] = strings.Join(secrets, ",")
+		}
+	} else {
+		if isAdd {
+			env.Annotations[key] = targetSecretName
 		}
 	}
 }


### PR DESCRIPTION
## Description

bugfix for error handle image registry; failed when env annotations is not empty;


## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note

```
