### PR TITLE
🐞 fix(log): alert duration in template limit to 10m

### DIFF
--- a/pkg/service/handlers/environment/handler.go
+++ b/pkg/service/handlers/environment/handler.go
@@ -829,7 +829,9 @@ func (h *EnvironmentHandler) EnvironmentObservabilityDetails(c *gin.Context) {
 					addRealtimeAlert(v.AlertLevels)
 				}
 			}
-			alertResourceMap["logging"] = len(logalerts)
+			if len(logalerts) > 0 {
+				alertResourceMap["logging"] = len(logalerts)
+			}
 			for _, v := range logalerts {
 				addRealtimeAlert(v.AlertLevels)
 			}


### PR DESCRIPTION
## Description

fix #151 



## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note
fix(log): alert duration in template limit to 10m
```
