### PR TITLE
🐞 fix(cluster): apiserver version should from k8s, not db

### DIFF
--- a/pkg/service/handlers/cluster/handler.go
+++ b/pkg/service/handlers/cluster/handler.go
@@ -69,6 +69,20 @@ func (h *ClusterHandler) ListCluster(c *gin.Context) {
 		handlers.NotOK(c, err)
 		return
 	}
+	eg := errgroup.Group{}
+	for i := range list {
+		index := i
+		eg.Go(func() error {
+			cli, err := h.GetAgents().ClientOf(c.Request.Context(), list[index].ClusterName)
+			if err != nil {
+				log.Error(err, "unable get agents client", "cluster", list[index].ClusterName)
+				return nil
+			}
+			list[index].Version = cli.APIServerVersion()
+			return nil
+		})
+	}
+	_ = eg.Wait()
 	handlers.OK(c, handlers.Page(total, list, int64(page), int64(size)))
 }
 
@@ -133,6 +147,12 @@ func (h *ClusterHandler) RetrieveCluster(c *gin.Context) {
 	if err := h.GetDataBase().DB().First(&obj, c.Param(PrimaryKeyName)).Error; err != nil {
 		handlers.NotOK(c, err)
 		return
+	}
+	cli, err := h.GetAgents().ClientOf(c.Request.Context(), obj.ClusterName)
+	if err != nil {
+		log.Error(err, "unable get agents client", "cluster", obj.ClusterName)
+	} else {
+		obj.Version = cli.APIServerVersion()
 	}
 	handlers.OK(c, obj)
 }


### PR DESCRIPTION
## Description

fix #162 



## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note

```
