### PR TITLE
🐞 fix(apiresource): handle apiresource group failed error

### DIFF
--- a/pkg/agent/apis/cluster.go
+++ b/pkg/agent/apis/cluster.go
@@ -2,7 +2,9 @@ package apis
 
 import (
 	"github.com/gin-gonic/gin"
+	"k8s.io/client-go/discovery"
 	"kubegems.io/kubegems/pkg/agent/cluster"
+	"kubegems.io/kubegems/pkg/log"
 )
 
 type ClusterHandler struct {
@@ -20,7 +22,14 @@ type ClusterHandler struct {
 func (h *ClusterHandler) APIResources(c *gin.Context) {
 	ret, err := h.cluster.Discovery().ServerPreferredResources()
 	if err != nil {
-		NotOK(c, err)
+		if discovery.IsGroupDiscoveryFailedError(err) {
+			log.Warnf("get api-resources failed: %v", err)
+			OK(c, ret)
+			return
+		} else {
+			NotOK(c, err)
+			return
+		}
 	}
 	OK(c, ret)
 }


### PR DESCRIPTION
## Description

agent log:
```log
2022-07-29 02:51:11.406 error   apis/types.go:19        notok: unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request


2022/07/29 02:51:11 [Recovery] 2022/07/29 - 02:51:11 panic recovered:
json: unsupported type: map[schema.GroupVersion]error
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/render/json.go:58 (0xbcb17d)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/context.go:910 (0xc4b0bc)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/context.go:953 (0xc4b673)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/context.go:204 (0xc45845)
/home/runner/work/kubegems/kubegems/pkg/agent/apis/types.go:29 (0x3a3f944)
/home/runner/work/kubegems/kubegems/pkg/agent/apis/cluster.go:23 (0x3a17244)
/home/runner/work/kubegems/kubegems/pkg/agent/apis/apis.go:108 (0x3a11fe3)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/context.go:173 (0xc456dc)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/recovery.go:101 (0xc58817)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/context.go:173 (0xc456dc)
/home/runner/work/kubegems/kubegems/pkg/utils/prometheus/exporter/http_request.go:80 (0x37d5209)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/context.go:173 (0xc456dc)
/home/runner/work/kubegems/kubegems/pkg/log/gin.go:37 (0xd4abe4)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/context.go:173 (0xc456dc)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/gin.go:613 (0xc54e48)
/home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.8.0/gin.go:569 (0xc5491a)
/opt/hostedtoolcache/go/1.18.3/x64/src/net/http/server.go:2916 (0x93ccd3)
/opt/hostedtoolcache/go/1.18.3/x64/src/net/http/server.go:3523 (0x941332)
/opt/hostedtoolcache/go/1.18.3/x64/src/net/http/h2_bundle.go:5903 (0x8f7fa7)
/opt/hostedtoolcache/go/1.18.3/x64/src/runtime/asm_amd64.s:1571 (0x4721e0)

2022-07-29 02:51:11.407 error   gin@v1.8.0/context.go:173       Internal Server Error   {"method": "GET", "path": "/v1/api-resources", "code": 500, "latency": 5.203448909}
```

fixed.



## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note

```
