### PR TITLE
bugfix(id: 178): add thirdparty crd roles tracked by events

### DIFF
--- a/deploy/plugins/argo-rollouts/templates/rollout-crd-view.yaml
+++ b/deploy/plugins/argo-rollouts/templates/rollout-crd-view.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    bundle.kubegems.io/ignore-options: OnUpdate
+  labels:
+    app: rollout-crd-view
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: rollout-crd-view
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/plugins/kubegems/templates/kuebgems-crd-view.yaml
+++ b/deploy/plugins/kubegems/templates/kuebgems-crd-view.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    bundle.kubegems.io/ignore-options: OnUpdate
+  labels:
+    app: kubegems-crd-view
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: kubegems-crd-view
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - analysisruns
+  - analysistemplates
+  - applications
+  - applicationsets
+  - appprojects
+  - clusteranalysistemplates
+  - experiments
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/plugins/kubevela/templates/kubevela-crd-view.yaml
+++ b/deploy/plugins/kubevela/templates/kubevela-crd-view.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    bundle.kubegems.io/ignore-options: OnUpdate
+  labels:
+    app: kubevela-crd-view
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: kubevela-crd-view
+rules:
+- apiGroups:
+  - core.oam.dev
+  resources:
+  - applicationrevisions
+  - applications
+  - componentdefinitions
+  - definitionrevisions
+  - policydefinitions
+  - resourcetrackers
+  - scopedefinitions
+  - traitdefinitions
+  - workflows
+  - workflowstepdefinitions
+  - workloaddefinitions
+  - envbindings
+  - policies
+  - healthscopes
+  - manualscalertraits
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - standard.oam.dev
+  resources:
+  - rollouts
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/plugins/logging/templates/logging-crd-view.yaml
+++ b/deploy/plugins/logging/templates/logging-crd-view.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    bundle.kubegems.io/ignore-options: OnUpdate
+  labels:
+    app: logging-crd-view
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: logging-crd-view
+rules:
+- apiGroups:
+  - logging-extensions.banzaicloud.io
+  resources:
+  - eventtailers
+  - hosttailers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - logging.banzaicloud.io
+  resources:
+  - clusterflows
+  - clusteroutputs
+  - flows
+  - loggings
+  - outputs
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/plugins/openkruise/templates/openkruise-crd-view.yaml
+++ b/deploy/plugins/openkruise/templates/openkruise-crd-view.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    bundle.kubegems.io/ignore-options: OnUpdate
+  labels:
+    app: kruise-crd-view
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: kruise-crd-view
+rules:
+- apiGroups:
+  - apps.kruise.io
+  resources:
+  - nodeimages
+  - sidecarsets
+  - imagepulljobs
+  - persistentpodstates
+  - uniteddeployments
+  - workloadspreads
+  - advancedcronjobs
+  - broadcastjobs
+  - containerrecreaterequests
+  - clonesets
+  - daemonsets
+  - resourcedistributions
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - policy.kruise.io
+  resources:
+  - podunavailablebudgets
+  verbs:
+  - get
+  - list
+  - watch

--- a/deploy/plugins/volume-snapshoter/templates/external-snapshotter-crd-view.yaml
+++ b/deploy/plugins/volume-snapshoter/templates/external-snapshotter-crd-view.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    bundle.kubegems.io/ignore-options: OnUpdate
+  labels:
+    app: external-snapshotter-crd-view
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: external-snapshotter-crd-view
+rules:
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  - volumesnapshotcontents
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
## Description

Add the default clusterroles for each plugin ,and associate it to `clusterroles/view`,

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

add thirdparty crd roles tracked by events

```release-note
add thirdparty crd roles tracked by events
```
