### PR TITLE
bugfix: imagePullSecrets error

### DIFF
--- a/pkg/controller/controllers/environment_controller.go
+++ b/pkg/controller/controllers/environment_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"kubegems.io/kubegems/pkg/apis/application"
 	gemlabels "kubegems.io/kubegems/pkg/apis/gems"
 	gemsv1beta1 "kubegems.io/kubegems/pkg/apis/gems/v1beta1"
 	"kubegems.io/kubegems/pkg/utils/maps"
@@ -37,10 +38,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-)
-
-const (
-	imagePullSecretKeyPrefix = "kubegems.io/imagePullSecrets-"
 )
 
 // EnvironmentReconciler reconciles a Environment object
@@ -293,8 +290,8 @@ func (r *EnvironmentReconciler) handleServiceAccount(env *gemsv1beta1.Environmen
 	}
 
 	for k := range env.Annotations {
-		if strings.HasPrefix(k, imagePullSecretKeyPrefix) {
-			saName := strings.TrimPrefix(k, imagePullSecretKeyPrefix)
+		if strings.HasPrefix(k, application.AnnotationImagePullSecretKeyPrefix) {
+			saName := strings.TrimPrefix(k, application.AnnotationImagePullSecretKeyPrefix)
 			if sa, ok := saMap[saName]; ok {
 				secrets, hasDiff := imagePullSecretHasDiff(sa.ImagePullSecrets, env.Annotations[k])
 				if hasDiff {

--- a/pkg/service/handlers/environment/handler.go
+++ b/pkg/service/handlers/environment/handler.go
@@ -37,9 +37,9 @@ import (
 	msgclient "kubegems.io/kubegems/pkg/msgbus/client"
 	"kubegems.io/kubegems/pkg/service/handlers"
 	"kubegems.io/kubegems/pkg/service/handlers/base"
+	"kubegems.io/kubegems/pkg/service/handlers/registry/synchronizer"
 	"kubegems.io/kubegems/pkg/service/models"
 	"kubegems.io/kubegems/pkg/utils"
-	ut "kubegems.io/kubegems/pkg/utils"
 	"kubegems.io/kubegems/pkg/utils/agents"
 	"kubegems.io/kubegems/pkg/utils/loki"
 	"kubegems.io/kubegems/pkg/utils/msgbus"
@@ -225,7 +225,7 @@ func AfterEnvironmentSave(ctx context.Context, h base.BaseHandler, tx *gorm.DB, 
 		limitRange    []corev1.LimitRangeItem
 		resourceQuota corev1.ResourceList
 	)
-	if e := tx.Preload("Tenant").First(&project, "id = ?", env.ProjectID).Error; e != nil {
+	if e := tx.Preload("Tenant").Preload("Registries").First(&project, "id = ?", env.ProjectID).Error; e != nil {
 		return e
 	}
 	if e := tx.First(&cluster, "id = ?", env.ClusterID).Error; e != nil {
@@ -263,7 +263,9 @@ func AfterEnvironmentSave(ctx context.Context, h base.BaseHandler, tx *gorm.DB, 
 	if e := createOrUpdateEnvironment(ctx, h, cluster.ClusterName, env.EnvironmentName, spec); e != nil {
 		return e
 	}
-	return nil
+	env.Cluster = &cluster
+	syncer := synchronizer.SynchronizerFor(h)
+	return syncer.SyncRegistries(ctx, []*models.Environment{env}, project.Registries, synchronizer.SyncKindUpsert)
 }
 
 func createOrUpdateEnvironment(ctx context.Context, h base.BaseHandler, clustername, environment string, spec v1beta1.EnvironmentSpec) error {
@@ -560,7 +562,7 @@ func (h *EnvironmentHandler) GetEnvironmentResource(c *gin.Context) {
 		dateTime = time.Now().Add(-24 * time.Hour)
 	}
 	// 第二天的0点
-	dayTime := ut.NextDayStartTime(dateTime)
+	dayTime := utils.NextDayStartTime(dateTime)
 
 	env := models.Environment{}
 	if err := h.GetDB().Preload("Project.Tenant").Where("id = ?", c.Param("environment_id")).First(&env).Error; err != nil {

--- a/pkg/service/handlers/registry/registry-hook.go
+++ b/pkg/service/handlers/registry/registry-hook.go
@@ -16,33 +16,13 @@ package registryhandler
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
-	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"kubegems.io/kubegems/pkg/apis/application"
-	"kubegems.io/kubegems/pkg/apis/gems/v1beta1"
-	"kubegems.io/kubegems/pkg/log"
+	"kubegems.io/kubegems/pkg/service/handlers/registry/synchronizer"
 	"kubegems.io/kubegems/pkg/service/models"
-	"kubegems.io/kubegems/pkg/utils/agents"
 	"kubegems.io/kubegems/pkg/utils/harbor"
-	"kubegems.io/kubegems/pkg/utils/slice"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-)
-
-const (
-	syncKindUpsert = "upsert"
-	syncKindDelete = "delete"
-
-	imagePullSecretKeyPrefix  = application.AnnotationImagePullSecretKeyPrefix
-	defaultServiceAccountName = "default"
 )
 
 func (h *RegistryHandler) onChange(ctx context.Context, tx *gorm.DB, v *models.Registry) error {
@@ -51,14 +31,14 @@ func (h *RegistryHandler) onChange(ctx context.Context, tx *gorm.DB, v *models.R
 		return err
 	}
 	// sync
-	if e := h.syncRegistry(ctx, v, tx, syncKindUpsert); e != nil {
+	if e := h.syncRegistry(ctx, v, tx, synchronizer.SyncKindUpsert); e != nil {
 		return fmt.Errorf("同步镜像仓库信息到集群下失败 %w", e)
 	}
 	return nil
 }
 
 func (h *RegistryHandler) onDelete(ctx context.Context, tx *gorm.DB, v *models.Registry) error {
-	if e := h.syncRegistry(ctx, v, tx, syncKindDelete); e != nil {
+	if e := h.syncRegistry(ctx, v, tx, synchronizer.SyncKindDelete); e != nil {
 		return fmt.Errorf("同步镜像仓库信息到集群下失败 %w", e)
 	}
 	return nil
@@ -92,100 +72,10 @@ func (h *RegistryHandler) validate(ctx context.Context, v *models.Registry) erro
 }
 
 func (h *RegistryHandler) syncRegistry(ctx context.Context, reg *models.Registry, tx *gorm.DB, kind string) error {
-	var envs []models.Environment
+	var envs []*models.Environment
 	if e := tx.Preload("Cluster").Find(&envs, "project_id = ?", reg.ProjectID).Error; e != nil {
 		return e
 	}
-
-	secretName := reg.RegistryName
-
-	// 并发处理env
-	group := errgroup.Group{}
-	for _, v := range envs {
-		env := v // 必须重新赋值，ref. https://golang.org/doc/faq#closures_and_goroutines
-		group.Go(func() error {
-			return h.Execute(ctx, env.Cluster.ClusterName, func(ctx context.Context, cli agents.Client) error {
-				environment := &v1beta1.Environment{}
-				if err := cli.Get(ctx, client.ObjectKey{Name: env.EnvironmentName}, environment); err != nil {
-					return err
-				}
-				secret := &v1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      secretName,
-						Namespace: env.Namespace,
-					},
-				}
-				switch kind {
-				case syncKindUpsert:
-					_, err := controllerutil.CreateOrUpdate(ctx, cli, secret, func() error {
-						return updateSecretData(reg, secret)
-					})
-					if err != nil {
-						return err
-					}
-				case syncKindDelete:
-					if err := cli.Delete(ctx, secret); err != nil {
-						return err
-					}
-				}
-
-				// 默认仓库添加annotation
-				updateEnviromentAnnotation(environment, defaultServiceAccountName, secretName, (kind == syncKindUpsert && reg.IsDefault))
-				// 更新 env
-				return cli.Update(ctx, environment)
-			})
-		})
-	}
-	if err := group.Wait(); err != nil {
-		log.Error(err, "sync registry")
-		return err
-	}
-	return nil
-}
-
-func updateSecretData(v *models.Registry, in *v1.Secret) error {
-	in.Type = v1.SecretTypeDockerConfigJson
-
-	dockerAuthContent := map[string]interface{}{
-		"auths": map[string]interface{}{
-			v.RegistryAddress: map[string]interface{}{
-				"username": v.Username,
-				"password": v.Password,
-				"email":    "",
-				"auth":     base64.StdEncoding.EncodeToString([]byte(v.Username + ":" + v.Password)),
-			},
-		},
-	}
-	jsonStr, _ := json.Marshal(dockerAuthContent)
-	if in.Data == nil {
-		in.Data = make(map[string][]byte)
-	}
-	in.Data[v1.DockerConfigJsonKey] = jsonStr
-	return nil
-}
-
-func updateEnviromentAnnotation(env *v1beta1.Environment, serviceAccountName, targetSecretName string, isAdd bool) {
-	if env.Annotations == nil {
-		env.Annotations = make(map[string]string)
-	}
-	key := imagePullSecretKeyPrefix + serviceAccountName
-	if _, exist := env.Annotations[key]; exist {
-		secrets := strings.Split(env.Annotations[key], ",")
-		if isAdd {
-			if !slice.ContainStr(secrets, targetSecretName) {
-				secrets = append(secrets, targetSecretName)
-			}
-		} else {
-			secrets = slice.RemoveStrInReplace(secrets, targetSecretName)
-		}
-		if len(secrets) == 0 {
-			delete(env.Annotations, key)
-		} else {
-			env.Annotations[key] = strings.Join(secrets, ",")
-		}
-	} else {
-		if isAdd {
-			env.Annotations[key] = targetSecretName
-		}
-	}
+	syncer := synchronizer.SynchronizerFor(h.BaseHandler)
+	return syncer.SyncRegistries(ctx, envs, []*models.Registry{reg}, kind)
 }

--- a/pkg/service/handlers/registry/synchronizer/imageRegistrySynchronizer.go
+++ b/pkg/service/handlers/registry/synchronizer/imageRegistrySynchronizer.go
@@ -15,7 +15,7 @@ import (
 	"kubegems.io/kubegems/pkg/log"
 	"kubegems.io/kubegems/pkg/service/handlers/base"
 	"kubegems.io/kubegems/pkg/service/models"
-	"kubegems.io/kubegems/pkg/utils/slice"
+	"kubegems.io/kubegems/pkg/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -130,11 +130,15 @@ func UpdateEnviromentAnnotation(env *v1beta1.Environment, serviceAccountName str
 	key := imagePullSecretKeyPrefix + serviceAccountName
 	if _, exist := env.Annotations[key]; exist {
 		secrets := strings.Split(env.Annotations[key], ",")
+
+		secretSet := set.NewSet[string]()
 		if isAdd {
-			secrets = slice.StringUniqueSlice(append(secrets, newSecrets...))
+			secretSet.Append(secrets...)
+			secretSet.Append(newSecrets...)
 		} else {
-			secrets = slice.StringUniqueSliceRemove(secrets, newSecrets)
+			secretSet.Remove(newSecrets...)
 		}
+		secrets = secretSet.Slice()
 		if len(secrets) == 0 {
 			delete(env.Annotations, key)
 		} else {

--- a/pkg/service/handlers/registry/synchronizer/imageRegistrySynchronizer.go
+++ b/pkg/service/handlers/registry/synchronizer/imageRegistrySynchronizer.go
@@ -1,0 +1,148 @@
+package synchronizer
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"kubegems.io/kubegems/pkg/apis/application"
+	"kubegems.io/kubegems/pkg/apis/gems/v1beta1"
+	"kubegems.io/kubegems/pkg/log"
+	"kubegems.io/kubegems/pkg/service/handlers/base"
+	"kubegems.io/kubegems/pkg/service/models"
+	"kubegems.io/kubegems/pkg/utils/slice"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	SyncKindUpsert = "upsert"
+	SyncKindDelete = "delete"
+
+	imagePullSecretKeyPrefix  = application.AnnotationImagePullSecretKeyPrefix
+	defaultServiceAccountName = "default"
+)
+
+type ImageRegistrySynchronizer struct {
+	base.BaseHandler
+}
+
+func SynchronizerFor(h base.BaseHandler) *ImageRegistrySynchronizer {
+	return &ImageRegistrySynchronizer{
+		BaseHandler: h,
+	}
+}
+
+func (h *ImageRegistrySynchronizer) SyncRegistries(ctx context.Context, environments []*models.Environment, registries []*models.Registry, kind string) error {
+
+	for _, env := range environments {
+		if env.Cluster == nil {
+			return errors.New("failed to SyncRegistries, required environments with cluster property")
+		}
+	}
+
+	group := errgroup.Group{}
+	for idx := range environments {
+		env := environments[idx]
+		group.Go(func() error {
+			cli, err := h.GetAgents().ClientOf(ctx, env.Cluster.ClusterName)
+			if err != nil {
+				return err
+			}
+			environment := &v1beta1.Environment{}
+			if err := cli.Get(ctx, client.ObjectKey{Name: env.EnvironmentName}, environment); err != nil {
+				return err
+			}
+			secrets := []string{}
+			// TODO: Is it necessary to update/delete secrets concurrenctly ??
+			for _, reg := range registries {
+				secretName := reg.RegistryName
+				secret := &v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretName,
+						Namespace: env.Namespace,
+					},
+				}
+				switch kind {
+				case SyncKindUpsert:
+					_, err := controllerutil.CreateOrUpdate(ctx, cli, secret, func() error {
+						return updateSecretData(reg, secret)
+					})
+					if err != nil {
+						return err
+					}
+					if reg.IsDefault {
+						secrets = append(secrets, secretName)
+					}
+				case SyncKindDelete:
+					if err := cli.Delete(ctx, secret); err != nil {
+						return err
+					}
+					secrets = append(secrets, secretName)
+				}
+			}
+
+			_, err = controllerutil.CreateOrUpdate(ctx, cli, environment, func() error {
+				UpdateEnviromentAnnotation(environment, defaultServiceAccountName, secrets, kind == SyncKindUpsert)
+				return nil
+			})
+			return err
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		log.Error(err, "sync registry")
+		return err
+	}
+	return nil
+}
+
+func updateSecretData(v *models.Registry, in *v1.Secret) error {
+	in.Type = v1.SecretTypeDockerConfigJson
+
+	dockerAuthContent := map[string]interface{}{
+		"auths": map[string]interface{}{
+			v.RegistryAddress: map[string]interface{}{
+				"username": v.Username,
+				"password": v.Password,
+				"email":    "",
+				"auth":     base64.StdEncoding.EncodeToString([]byte(v.Username + ":" + v.Password)),
+			},
+		},
+	}
+	jsonStr, _ := json.Marshal(dockerAuthContent)
+	if in.Data == nil {
+		in.Data = make(map[string][]byte)
+	}
+	in.Data[v1.DockerConfigJsonKey] = jsonStr
+	return nil
+}
+
+func UpdateEnviromentAnnotation(env *v1beta1.Environment, serviceAccountName string, newSecrets []string, isAdd bool) {
+	if env.Annotations == nil {
+		env.Annotations = make(map[string]string)
+	}
+	key := imagePullSecretKeyPrefix + serviceAccountName
+	if _, exist := env.Annotations[key]; exist {
+		secrets := strings.Split(env.Annotations[key], ",")
+		if isAdd {
+			secrets = slice.StringUniqueSlice(append(secrets, newSecrets...))
+		} else {
+			secrets = slice.StringUniqueSliceRemove(secrets, newSecrets)
+		}
+		if len(secrets) == 0 {
+			delete(env.Annotations, key)
+		} else {
+			env.Annotations[key] = strings.Join(secrets, ",")
+		}
+	} else {
+		if isAdd {
+			env.Annotations[key] = strings.Join(newSecrets, ",")
+		}
+	}
+}

--- a/pkg/utils/set/set.go
+++ b/pkg/utils/set/set.go
@@ -27,14 +27,12 @@ type Ordered interface {
 
 // Set 是一个*有序的*，非空的，不重复的 string 元素的集合。
 type Set[T Ordered] struct {
-	elems []T
-	maps  map[T]struct{}
+	maps map[T]struct{}
 }
 
 func NewSet[T Ordered]() *Set[T] {
 	return &Set[T]{
-		elems: []T{},
-		maps:  map[T]struct{}{},
+		maps: map[T]struct{}{},
 	}
 }
 
@@ -48,19 +46,27 @@ func (s *Set[T]) Append(vals ...T) *Set[T] {
 		if _, ok := s.maps[val]; ok {
 			continue
 		}
-		s.elems = append(s.elems, val)
 		s.maps[val] = struct{}{}
 	}
 	return s
 }
 
-func (s *Set[T]) Slice() []T {
-	sort.Slice(s.elems, func(i, j int) bool {
-		return s.elems[i] < s.elems[j]
+func (s *Set[T]) Slice() (r []T) {
+	for k := range s.maps {
+		r = append(r, k)
+	}
+	sort.Slice(r, func(i, j int) bool {
+		return r[i] < r[j]
 	})
-	return s.elems
+	return
+}
+
+func (s *Set[T]) Remove(elems ...T) {
+	for _, elem := range elems {
+		delete(s.maps, elem)
+	}
 }
 
 func (s *Set[T]) Len() int {
-	return len(s.elems)
+	return len(s.maps)
 }

--- a/pkg/utils/set/set_test.go
+++ b/pkg/utils/set/set_test.go
@@ -31,7 +31,7 @@ func TestSlice(t *testing.T) {
 			name:       "string",
 			elems:      []string{"a", "a", "b", "c"},
 			want:       []string{"a", "b", "c"},
-			wantlength: 3,
+			wantlength: 2,
 		},
 	}
 
@@ -41,6 +41,10 @@ func TestSlice(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := set.Slice(); slice.SliceUniqueKey(got) != slice.SliceUniqueKey(tt.want) {
 				t.Errorf("Slice() = %v, want %v", got, tt.want)
+			}
+			set.Remove("c")
+			if set.Has("c") {
+				t.Errorf("Has(\"c\") = true, want false")
 			}
 			if length := set.Len(); length != tt.wantlength {
 				t.Errorf("Len() = %v, want %v", length, tt.wantlength)

--- a/pkg/utils/slice/string.go
+++ b/pkg/utils/slice/string.go
@@ -69,30 +69,3 @@ func SliceUniqueKey(s []string) string {
 	sort.Strings(tmp)
 	return strings.Join(tmp, "-")
 }
-
-func StringUniqueSlice(s []string) []string {
-	tmp := make(map[string]int)
-	for _, i := range s {
-		tmp[i]++
-	}
-	ret := []string{}
-	for v := range tmp {
-		ret = append(ret, v)
-	}
-	return ret
-}
-
-func StringUniqueSliceRemove(src []string, dest []string) []string {
-	tmp := make(map[string]int)
-	for _, i := range src {
-		tmp[i]++
-	}
-	for _, i := range dest {
-		delete(tmp, i)
-	}
-	ret := []string{}
-	for v := range tmp {
-		ret = append(ret, v)
-	}
-	return ret
-}

--- a/pkg/utils/slice/string.go
+++ b/pkg/utils/slice/string.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// src中是否存在了dest字符串
+// ContainStr src contains dest
 func ContainStr(src []string, dest string) bool {
 	for i := range src {
 		if src[i] == dest {
@@ -68,4 +68,31 @@ func SliceUniqueKey(s []string) string {
 	tmp := append([]string{}, s...)
 	sort.Strings(tmp)
 	return strings.Join(tmp, "-")
+}
+
+func StringUniqueSlice(s []string) []string {
+	tmp := make(map[string]int)
+	for _, i := range s {
+		tmp[i]++
+	}
+	ret := []string{}
+	for v := range tmp {
+		ret = append(ret, v)
+	}
+	return ret
+}
+
+func StringUniqueSliceRemove(src []string, dest []string) []string {
+	tmp := make(map[string]int)
+	for _, i := range src {
+		tmp[i]++
+	}
+	for _, i := range dest {
+		delete(tmp, i)
+	}
+	ret := []string{}
+	for v := range tmp {
+		ret = append(ret, v)
+	}
+	return ret
 }


### PR DESCRIPTION

## Description

bugfix for issue: https://github.com/kubegems/kubegems/issues/181


## Type of change


- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note
bugfix: environment created after default image registry created lose imagePullSecrets in default serviceAccount
```
