### PR TITLE
🐞 fix(eventer): drop 'lease' event

### DIFF
--- a/deploy/plugins/eventer/templates/eventer.yaml
+++ b/deploy/plugins/eventer/templates/eventer.yaml
@@ -19,6 +19,8 @@ spec:
         routes:
           - match:
               - receiver: "dump"
+            drop:
+              - kind: "Lease"
       receivers:
         - name: "dump"
           file:


### PR DESCRIPTION
## Description
fix eventer log:

{"level":"error","error":"[leases.coordination.k8s.io](http://leases.coordination.k8s.io/) \"[541a35fa.kubegems.io](http://541a35fa.kubegems.io/)\" is forbidden: User \"system:serviceaccount:kubegems-eventer:kubernetes-event-exporter\" cannot get resource \"leases\" in API group \"[coordination.k8s.io](http://coordination.k8s.io/)\" in the namespace \"ingress-nginx-operator-system\"","time":"2022-08-23T11:25:57Z","caller":"/bitnami/blacksmith-sandox/kubernetes-event-exporter-0.11.0/src/[github.com/opsgenie/kubernetes-event-exporter/pkg/kube/watcher.go:84](http://github.com/opsgenie/kubernetes-event-exporter/pkg/kube/watcher.go:84)","message":"Cannot list annotations of the object"}


## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note

```
