### PR TITLE
feat(spm): upgrade jaeger and opentelmetry

### DIFF
--- a/deploy/plugins/opentelemetry/Chart.yaml
+++ b/deploy/plugins/opentelemetry/Chart.yaml
@@ -5,5 +5,5 @@ dependencies:
   - name: common
     repository: file://../common
     version: 1.x.x
-appVersion: 0.20.0
+appVersion: 0.28.0
 description: OpenTelemetry是一个API和SDK的集合工具, 您可用它来检测、生成、收集和输出遥测数据（指标、日志和跟踪），以帮助分析软件的性能和行为

--- a/deploy/plugins/opentelemetry/templates/opentelemetry.yaml
+++ b/deploy/plugins/opentelemetry/templates/opentelemetry.yaml
@@ -13,6 +13,14 @@ spec:
       processors:
         k8sattributes:
           passthrough: true
+        spanmetrics:
+          metrics_exporter: prometheusremotewrite
+          latency_histogram_buckets: [1ms, 10ms, 100ms, 500ms, 1s, 10s]
+          dimensions_cache_size: 2000
+          dimensions:
+            - name: k8s.namespace.name
+            - name: k8s.pod.name
+            - name: http.status_code
       exporters:
         jaeger:
           endpoint: {{ .Values.tracing.jaeger.proto.address }}
@@ -24,13 +32,17 @@ spec:
           #  directory: /wal
           external_labels:
             source: opentelemetry
+            instance: ${MY_POD_IP}
           resource_to_telemetry_conversion:
             enabled: true
       service:
         pipelines:
           traces:
             processors:
+              - batch
+              - memory_limiter
               - k8sattributes
+              - spanmetrics
             exporters:
               - jaeger
           metrics:
@@ -40,12 +52,12 @@ spec:
       {{ include "common.images.repository" ( dict "registry" "docker.io" "repository" "otel/opentelemetry-collector-contrib" "context" .) }}
     mode: deployment
     replicaCount: 2
-    #extraConfigMapMounts:
+    #extraVolumeMounts:
     #- name: wal
     #  mountPath: /wal
     #extraVolumes:
     #- name: wal
-    #  emtyDir: 
+    #  emptyDir: {}
     ports:
       metrics:
         enabled: true

--- a/deploy/plugins/tracing/templates/observability.yaml
+++ b/deploy/plugins/tracing/templates/observability.yaml
@@ -26,6 +26,8 @@ spec:
         query:
           # image: jaegertracing/jaeger-query
           {{ include "common.images.repository" ( dict "key" "image" "registry" "docker.io" "repository" "jaegertracing/jaeger-query" "tag" $version "context" .) }}
+          metricsStorage:
+            type: prometheus
         ingester:
           # image: jaegertracing/jaeger-ingester
           {{ include "common.images.repository" ( dict "key" "image" "registry" "docker.io" "repository" "jaegertracing/jaeger-ingester" "tag" $version "context" .) }}
@@ -38,6 +40,7 @@ spec:
           options:
             collector.zipkin.host-port: "9411"
         storage:
+          secretName: jaeger-spm
           dependencies:
             enabled: false
           type: elasticsearch
@@ -51,6 +54,16 @@ spec:
               {{- else }}
               server-urls: http://elasticsearch-master.observability:9200
               {{- end }}
+
+---
+apiVersion: v1
+data:
+  PROMETHEUS_SERVER_URL: "{{ .Values.monitoring.prometheus.address  | b64enc }}"
+kind: Secret
+metadata:
+  name: jaeger-spm
+  namespace: {{ .Release.Namespace }}
+type: Opaque
 ---
 kind: Service
 apiVersion: v1

--- a/deploy/plugins/tracing/values.yaml
+++ b/deploy/plugins/tracing/values.yaml
@@ -1,6 +1,9 @@
 global:
   imageRegistry: ""
   imageRepository: ""
-chartVersion: 2.30.0
+chartVersion: 2.34.0
 elasticsearch:
   address: "" # override the default address
+monitoring:
+  prometheus:
+    address: ""


### PR DESCRIPTION
## Description

Enable Jaeger SPM to monitor application performace.

Update crd bebore upgrade jaeger-operator plugin.
```
kubectl apply -f https://raw.githubusercontent.com/jaegertracing/jaegeroperator/v1.36.0/config/crd/bases/jaegertracing.io_jaegers.yaml
```

## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Enable query application performace metrics from jaeger.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note
🚀 Plugins upgrade jaeger-operator-1.36 , opentelemetry-0.58.0
✨ enable Jaeger metrics from prometheus
```
