### PR TITLE
fix(#222): nacos installed on default namespace

### DIFF
--- a/deploy/plugins/nacos/templates/nacos.yaml
+++ b/deploy/plugins/nacos/templates/nacos.yaml
@@ -9,9 +9,13 @@ spec:
   path: helm
   version: master
   values:
+    global:
+      mode: cluster
+    namespace: "{{ .Release.Namespace }}"
     service:
       type: ClusterIP
     nacos:
+      replicaCount: 1
       image:
         # repository: nacos/nacos-server
         {{ include "common.images.repository" ( dict "registry" "docker.io" "repository" "nacos/nacos-server" "context" .) }}


### PR DESCRIPTION
## Description

Fixed  install wrong namespace when nacos plugin enable #222 


## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note
Fixed install wrong namespace when nacos plugin enable
```
