### PR TITLE
fix(plugins): add kubegems plugin by mistake

### DIFF
--- a/deploy/plugins/kubegems-models/plugin.yaml
+++ b/deploy/plugins/kubegems-models/plugin.yaml
@@ -1,7 +1,7 @@
 apiVersion: plugins.kubegems.io/v1beta1
 kind: Plugin
 metadata:
-  name: kubegems
+  name: kubegems-model
   annotations:
     plugins.kubegems.io/category: KubeGems
     plugins.kubegems.io/main-category: core


### PR DESCRIPTION
## Description

Fix kubegems plugin been overrided after cluster add.

## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

 
