### PR TITLE
fix: jaeger plugin doesn't upgrade to 1.36.0

### DIFF
--- a/deploy/plugins/tracing/Chart.yaml
+++ b/deploy/plugins/tracing/Chart.yaml
@@ -5,5 +5,5 @@ dependencies:
   - name: common
     repository: file://../common
     version: 1.x.x
-appVersion: 1.30.0
+appVersion: 1.36.0
 description: KubeGems平台应用链路追踪套件(Jaeger)


### PR DESCRIPTION
## Description

Jaeger operator doesn't upgrade to 1.36.0 when enable tracing plugin

## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note
fix: jaeger operator doesn't upgrade to 1.36.0
```
