### PR TITLE
enhancement: get environment resourcequota in concurrcy

### DIFF
--- a/pkg/service/handlers/cluster/handler.go
+++ b/pkg/service/handlers/cluster/handler.go
@@ -640,19 +640,5 @@ func (h *ClusterHandler) batchWithTimeout(ctx *gin.Context, clusters []*models.C
 			return nil
 		}(idx, cluster.ClusterName)
 	}
-	waitTimeout(&wg, timeout)
-}
-
-func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
-	c := make(chan struct{})
-	go func() {
-		defer close(c)
-		wg.Wait()
-	}()
-	select {
-	case <-c:
-		return false
-	case <-time.After(timeout):
-		return true
-	}
+	utils.WaitGroupWithTimeout(&wg, timeout)
 }

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -279,4 +280,18 @@ func ConvertBytes(bytes float64) string {
 	result := strconv.FormatFloat(value, 'f', 2, 64)
 	result = strings.TrimSuffix(result, ".00")
 	return result + unit
+}
+
+func WaitGroupWithTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false
+	case <-time.After(timeout):
+		return true
+	}
 }


### PR DESCRIPTION
## Description

get environment resourcequota in concurrency

## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note
get environment resourcequota in concurrency

```
