### PR TITLE
enhancement: force validate  clustername ^[a-z][-a-z0-9]{0,32}$

### DIFF
--- a/pkg/service/handlers/handlers.go
+++ b/pkg/service/handlers/handlers.go
@@ -46,8 +46,6 @@ const (
 	MessageError        = "err"
 	MessageForbidden    = "forbidden"
 	MessageUnauthorized = "unauthorized"
-
-	MethodList = "LIST"
 )
 
 type ResponseStruct struct {

--- a/pkg/service/models/model_cluster.go
+++ b/pkg/service/models/model_cluster.go
@@ -24,7 +24,7 @@ import (
 // Cluster 集群表
 type Cluster struct {
 	ID          uint           `gorm:"primarykey"`
-	ClusterName string         `gorm:"type:varchar(50);uniqueIndex" binding:"required"`
+	ClusterName string         `gorm:"type:varchar(50);uniqueIndex" binding:"required,fqdn_item"`
 	APIServer   string         `gorm:"type:varchar(250);uniqueIndex"` // APIServer地址 根据kubeconfig添加后，自动填充
 	KubeConfig  datatypes.JSON `binding:"required"`
 	// Vendor 集群提供商(gke tke ack selfhosted)

--- a/pkg/service/models/validate/base.go
+++ b/pkg/service/models/validate/base.go
@@ -61,10 +61,14 @@ func NewValidator(db *gorm.DB) (*Validator, error) {
 		db:         db,
 		Translator: trans,
 	}
-	if err := v.registCustomTags(); err != nil {
+	if err := v.registCustomValidator(); err != nil {
+		return nil, err
+	}
+	if err := v.registCustomTranslation(); err != nil {
 		return nil, err
 	}
 	v.registStructValidates()
+
 	return v, nil
 }
 
@@ -76,4 +80,11 @@ func (v *Validator) registStructValidates() {
 	v.Validator.RegisterStructValidation(v.TenantUserRelStructLevelValidation, models.TenantUserRels{})
 	v.Validator.RegisterStructValidation(v.EnvironmentUserRelStructLevelValidation, models.EnvironmentUserRels{})
 	v.Validator.RegisterStructValidation(v.UserCreateStructLevelValidation, models.UserCreate{})
+}
+
+func (v *Validator) registCustomValidator() error {
+	if e := v.Validator.RegisterValidation("fqdn_item", fqdn_item); e != nil {
+		return e
+	}
+	return nil
 }

--- a/pkg/service/models/validate/custom_tags.go
+++ b/pkg/service/models/validate/custom_tags.go
@@ -36,7 +36,7 @@ func translateFn(trans ut.Translator, fe validator.FieldError) string {
 	return msg
 }
 
-func (v *Validator) registCustomTags() error {
+func (v *Validator) registCustomTranslation() error {
 	if e := v.Validator.RegisterTranslation("dbuniq", v.Translator, registerTranslator("dbuniq", "{0} 为 {1} 的 {2} 已经存在了"), translateFn); e != nil {
 		return e
 	}
@@ -50,6 +50,9 @@ func (v *Validator) registCustomTags() error {
 		return e
 	}
 	if e := v.Validator.RegisterTranslation("password", v.Translator, registerTranslator("password", "密码长度至少8位,包含大小写字母和数字以及特殊字符(.!@#$%~)"), translateFn); e != nil {
+		return e
+	}
+	if e := v.Validator.RegisterTranslation("fqdn_item", v.Translator, registerTranslator("fqdn_item", "{0} 格式不合法，仅允许小写字母开头包含小写字母和数字以及减号且长度小于33个字符的字符串"), translateFn); e != nil {
 		return e
 	}
 	return nil

--- a/pkg/service/models/validate/custon_validator.go
+++ b/pkg/service/models/validate/custon_validator.go
@@ -1,0 +1,14 @@
+package validate
+
+import (
+	"regexp"
+
+	"github.com/go-playground/validator/v10"
+)
+
+var fqdn_item_reg = regexp.MustCompile("^[a-z][-a-z0-9]{0,32}$")
+
+var fqdn_item validator.Func = func(fl validator.FieldLevel) bool {
+	v := fl.Field().String()
+	return fqdn_item_reg.MatchString(v)
+}


### PR DESCRIPTION
## Description

enhancement for this issue, https://github.com/kubegems/kubegems/issues/280, the installer will use the cluster name as a global value in the helm chart, if use upper case CluserName, will caused downstream error


## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note
enhancement for https://github.com/kubegems/kubegems/issues/280
```
