### PR TITLE
feature: support logquery history add time_range, user can reuse time

### DIFF
--- a/pkg/service/handlers/cluster/handler.go
+++ b/pkg/service/handlers/cluster/handler.go
@@ -352,6 +352,7 @@ func (h *ClusterHandler) ListClusterLogQueryHistoryv2(c *gin.Context) {
 	rawsql := `select log_ql,
 		max(id) as id,
 		GROUP_CONCAT(id SEPARATOR ',') as ids,
+		GROUP_CONCAT(DISTINCT(time_range) SEPARATOR ',') as time_ranges,
 		any_value(cluster_id) as cluster_id,
 		max(create_at) as create_at,
 		any_value(filter_json) as filter_json,

--- a/pkg/service/models/model_log.go
+++ b/pkg/service/models/model_log.go
@@ -38,6 +38,8 @@ type LogQueryHistory struct {
 	FilterJSON string `gorm:"type:varchar(1024)"`
 	// logql
 	LogQL string `gorm:"type:varchar(1024)"`
+	// 时间区间
+	TimeRange string `gorm:"type:varchar(256);default:''"`
 	// 创建时间
 	CreateAt time.Time `sql:"DEFAULT:'current_timestamp'"`
 	// 创建者
@@ -48,6 +50,7 @@ type LogQueryHistory struct {
 type LogQueryHistoryWithCount struct {
 	ID         uint
 	Ids        string
+	TimeRanges string
 	Cluster    *Cluster
 	ClusterID  uint
 	LabelJSON  string


### PR DESCRIPTION
condition

## Description

for logquery history. user can re use the time range 


## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note

```
