### PR TITLE
Set the standard label for spanmetrics

### DIFF
--- a/deploy/plugins/nacos/templates/nacos.yaml
+++ b/deploy/plugins/nacos/templates/nacos.yaml
@@ -11,11 +11,19 @@ spec:
   values:
     namespace: {{ .Release.Namespace }}
     global:
+      {{ - if .Values.global.mode }}
+      mode: {{ .Values.global.mode }}
+      {{- else }}
       mode: cluster
+      {{- end }}
     service:
       type: ClusterIP
     nacos:
-      replicaCount: 1
+      {{- if .Values.nacos.replicaCount}}
+      replicaCount: {{ .Values.nacos.replicaCount }}
+      {{- else }}
+      replicaCount: 3
+      {{- end }}
       image:
         # repository: nacos/nacos-server
         {{ include "common.images.repository" ( dict "registry" "docker.io" "repository" "nacos/nacos-server" "context" .) }}

--- a/deploy/plugins/opentelemetry/templates/opentelemetry.yaml
+++ b/deploy/plugins/opentelemetry/templates/opentelemetry.yaml
@@ -18,8 +18,8 @@ spec:
           latency_histogram_buckets: [1ms, 10ms, 100ms, 500ms, 1s, 10s]
           dimensions_cache_size: 2000
           dimensions:
-            - name: k8s.namespace.name
-            - name: k8s.pod.name
+            - name: namespace
+            - name: pod
             - name: http.status_code
       exporters:
         jaeger:

--- a/deploy/plugins/tracing/templates/observability.yaml
+++ b/deploy/plugins/tracing/templates/observability.yaml
@@ -54,6 +54,15 @@ spec:
               {{- else }}
               server-urls: http://elasticsearch-master.observability:9200
               {{- end }}
+              {{- if .Values.elasticsearch.num-shards }}
+              num-shards: {{ .Values.elasticsearch.num-shards }}
+              {{- end }}
+              {{- if .Values.elasticsearch.num-replicas }}
+              num-replicas: {{ .Values.elasticsearch.num-replicas}}
+              {{- end }}
+              {{- if .Values.elasticsearch.timeout }}
+              timeout: {{ .Values.elasticsearch.timeout}}
+              {{- end }}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description
- Add jaeger and Nacos custom config on plugins values
- Set the standard label for spanmetrics  https://github.com/kubegems/kubegems/issues/313

## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note
Set the standard label for spanmetrics
```
