### PR TITLE
🐞 fix(channel): find alertrule must add 'where', sync map

### DIFF
--- a/pkg/service/handlers/observability/channel.go
+++ b/pkg/service/handlers/observability/channel.go
@@ -189,7 +189,7 @@ func (h *ObservabilityHandler) UpdateChannel(c *gin.Context) {
 		if err := tx.Model(&models.AlertReceiver{}).Distinct("alert_rule_id").Where("alert_channel_id = ?", req.ID).Scan(&alertruleIDs).Error; err != nil {
 			return err
 		}
-		return tx.Preload("Receivers.AlertChannel").Find(&alertrules, alertruleIDs).Error
+		return tx.Preload("Receivers.AlertChannel").Where("id in ?", alertruleIDs).Find(&alertrules).Error
 	}); err != nil {
 		handlers.NotOK(c, err)
 		return


### PR DESCRIPTION
## Description

#432 



## Type of change

_What type of changes does your code introduce to KubeGems? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Use useExistingAlertingGroup field in loki to replace build-in alertingroups
- Store alert rules in new configmap, to avoid overwrite on update.
-->

```release-note

```
