### PR TITLE
fix(edge): edge server lacks the healthz api route

### DIFF
--- a/deploy/addon-local-path-provisioner.yaml
+++ b/deploy/addon-local-path-provisioner.yaml
@@ -17,3 +17,33 @@ spec:
       - node: DEFAULT_PATH_FOR_NON_LISTED_NODES
         paths:
           - /data
+    image:
+      # repository: rancher/local-path-provisioner
+      repository: registry.cn-beijing.aliyuncs.com/kubegems/local-path-provisioner
+      tag: v0.0.22
+      pullPolicy: IfNotPresent
+    helperImage:
+      repository: registry.cn-beijing.aliyuncs.com/kubegems/busybox
+    configmap:
+      # specify the config map name
+      name: local-path-config
+      # specify the custom script for setup and teardown
+      setup: |-
+        #!/bin/sh
+        set -eu
+        mkdir -m 0777 -p "$VOL_DIR"
+      teardown: |-
+        #!/bin/sh
+        set -eu
+        rm -rf "$VOL_DIR"
+      # specify the custom helper pod yaml
+      helperPod: |-
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: helper-pod
+        spec:
+          containers:
+          - name: helper-pod
+            image: registry.cn-beijing.aliyuncs.com/kubegems/busybox:latest
+            imagePullPolicy: IfNotPresent

--- a/pkg/edge/server/server.go
+++ b/pkg/edge/server/server.go
@@ -20,11 +20,12 @@ import (
 	"net/http"
 
 	"golang.org/x/sync/errgroup"
+	"kubegems.io/library/rest/api"
+
 	"kubegems.io/kubegems/pkg/edge/tunnel"
 	"kubegems.io/kubegems/pkg/log"
 	"kubegems.io/kubegems/pkg/utils/pprof"
 	"kubegems.io/kubegems/pkg/utils/system"
-	"kubegems.io/library/rest/api"
 )
 
 func Run(ctx context.Context, options *Options) error {
@@ -97,5 +98,5 @@ func (s *EdgeServer) HTTPAPI() http.Handler {
 		Cluster: s.clusters,
 		Tunnel:  s.server.TunnelServer,
 	}
-	return api.NewAPI().Register("/v1", edgeapi).BuildHandler()
+	return api.NewAPI().HealthCheck(nil).Register("/v1", edgeapi).BuildHandler()
 }


### PR DESCRIPTION
## Description

```bash

Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  60s                default-scheduler  Successfully assigned kubegems-edge/kubegems-edge-server-6fc558dd5b-nln46 to k3d-panlq-cluster-agent-0
  Normal   Pulled     59s                kubelet            Container image "registry.cn-beijing.aliyuncs.com/kubegems/kubegems:v1.24.5" already present on machine
  Normal   Created    59s                kubelet            Created container server
  Normal   Started    59s                kubelet            Started container server
  Warning  Unhealthy  30s                kubelet            Liveness probe failed: HTTP probe failed with statuscode: 404
  Warning  Unhealthy  5s (x10 over 50s)  kubelet            Readiness probe failed: HTTP probe failed with statuscode: 404

```



## Type of change

- [x] `BUGFIX` (non-breaking change which fixes an issue)


